### PR TITLE
Improve tilemap clear test

### DIFF
--- a/tests/test_tilemap.py
+++ b/tests/test_tilemap.py
@@ -101,4 +101,11 @@ def test_tilemap_clear(scene):
 
     tilemap.clear()
 
+    # All tiles previously written should now be gone.
+    for x in range(3, 6):
+        for y in range(6, 9):
+            assert tilemap.get((x, y)) is None
+
+    # Clearing one tilemap does not affect another tilemap in the same scene
     tm[4, 5] = 'bomb'
+    assert tm.get((4, 5)) == 'bomb'


### PR DESCRIPTION
## Summary
- ensure that clearing a tilemap removes previously set tiles
- verify another tilemap remains unaffected

## Testing
- `pip install -e .`
- `pytest -k test_tilemap_clear -q` *(fails: XOpenDisplay cannot open display)*

------
https://chatgpt.com/codex/tasks/task_e_684166a94dfc8328b24065e51034a2d4