### PR TITLE
Fix title type hint

### DIFF
--- a/wasabi2d/scene.py
+++ b/wasabi2d/scene.py
@@ -55,7 +55,7 @@ class Window:
             self,
             width: int = 800,
             height: int = 600,
-            title: int = "wasabi2d",
+            title: str = "wasabi2d",
             *,
             fullscreen: bool = False,
             icon: str = None,


### PR DESCRIPTION
## Summary
- correct type hint for window title

## Testing
- `pytest -q` *(fails: XOpenDisplay cannot open display)*

------
https://chatgpt.com/codex/tasks/task_e_684166581410832882059679c773f885