### PR TITLE
Fix typos in docs and scene

### DIFF
--- a/docs/sound.rst
+++ b/docs/sound.rst
@@ -47,7 +47,7 @@ stop the sound as well as query its length in seconds:
         Get the duration of the sound in seconds.
 
 You should avoid using the ``sounds`` object to play longer pieces of music.
-Because the sounds sytem will fully load the music into memory before playing
+Because the sounds system will fully load the music into memory before playing
 it, this can use a lot of memory, as well as introducing a delay while the
 music is loaded.
 

--- a/wasabi2d/scene.py
+++ b/wasabi2d/scene.py
@@ -193,7 +193,7 @@ class Window:
         pygame.display.set_caption(title)
 
     def on_screenshot_requested(self, video):
-        """Handle a screenshot event from the event sytem."""
+        """Handle a screenshot event from the event system."""
         if video:
             self.toggle_recording()
         else:


### PR DESCRIPTION
## Summary
- fix typo in Scene docstring
- fix typo in sound documentation
- build docs to ensure Sphinx runs

## Testing
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_68416645fc448328b20915ce93ff8973